### PR TITLE
🐛  Remove static methods from SMS class

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
             ],
             "aliases": {
                 "SMS": "Xenon\\LaravelBDSms\\Facades\\SMS",
-                "LaravelBDSms": "Xenon\\LaravelBDSms\\LaravelBDSmsServiceProvider"
+                "LaravelBDSms": "Xenon\\LaravelBDSms\\Facades\\SMS"
             }
         }
     }

--- a/readme.md
+++ b/readme.md
@@ -20,6 +20,13 @@ use Xenon\LaravelBDSms\Facades\SMS;
 SMS::shoot('017XXYYZZAA', 'helloooooooo boss!');
 </pre>
 
+or, with facade alias
+<pre>
+use LaravelBDSms;
+
+LaravelBDSms::shoot('017XXYYZZAA', 'helloooooooo boss!');
+</pre>
+
 Or, if you need to change the default provider on the fly
 <pre>
 use Xenon\LaravelBDSms\Facades\SMS;

--- a/src/Facades/SMS.php
+++ b/src/Facades/SMS.php
@@ -3,7 +3,8 @@
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static void shoot(string $mobile, string $text)
+ * @method static \Xenon\LaravelBDSms\SMS via(string $provider)
+ * @method static mixed shoot(string $mobile, string $text)
  *
  * @see \Xenon\LaravelBDSms\SMS
  */

--- a/src/SMS.php
+++ b/src/SMS.php
@@ -5,12 +5,11 @@ use Exception;
 class SMS
 {
     /** @var Sender */
-    private static $sender;
-
+    private $sender;
 
     public function __construct(Sender $sender)
     {
-        self::$sender = $sender;
+        $this->sender = $sender;
     }
 
     /**
@@ -29,17 +28,10 @@ class SMS
      * @throws Handler\ValidationException
      * @throws Exception
      */
-    public static function shoot(string $number, string $text)
+    public function shoot(string $number, string $text)
     {
-        /*$config = Config::get('sms');
-
-
-        self::$sender = new Sender();
-        self::$sender->setMobile($number);
-        self::$sender->setMessage($text);
-        return self::$sender->send();*/
-        self::$sender->setMobile($number);
-        self::$sender->setMessage($text);
-        return self::$sender->send();
+        $this->sender->setMobile($number);
+        $this->sender->setMessage($text);
+        return $this->sender->send();
     }
 }

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -22,7 +22,7 @@ use Xenon\LaravelBDSms\Provider\AbstractProvider;
 class Sender
 {
     /**
-     * @var
+     * @var AbstractProvider
      */
     private $provider;
     /**


### PR DESCRIPTION
Type(s): FIX

Why:
SMS class should not contain statics. As it sits on the container, if
static is used then container can be bypassed, and it will pollute the
global space. And also, changing provider on the fly does not work.
Static methods are provided via the facade itself.

What:
1. Make SMS class accesible via instance. 
2. Change alias in composer.json, as it should point to the facade.