### PR TITLE
Fix broken step links

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -9,10 +9,10 @@ gateways for <strong>Laravel Framework</strong>.
 
 <!-- TOC -->
 * [Installation](#installation)
-  * [Step 1:](#step-1-)
-  * [Step 2:](#step-2-)
-  * [Step 3:](#step-3-)
-  * [Step 4:](#step-4-)
+  * [Step 1:](#step-1)
+  * [Step 2:](#step-2)
+  * [Step 3:](#step-3)
+  * [Step 4:](#step-4)
   * [Usage](#usage)
     * [Simply use the facade](#simply-use-the-facade)
     * [Or, with facade alias](#or-with-facade-alias)


### PR DESCRIPTION
Clicking on those step anchors doesn't go anywhere because of broken anchoring.

I've fixed those step broken links by removing trailing `-`