### PR TITLE
Update ElitBuzz.php

### DIFF
--- a/src/Provider/ElitBuzz.php
+++ b/src/Provider/ElitBuzz.php
@@ -35,12 +35,12 @@ class ElitBuzz extends AbstractProvider
         $tries=$this->senderObject->getTries();
         $backoff=$this->senderObject->getBackoff();
 
-        $formParams = [
+      $formParams = [
             "api_key" => $config['api_key'],
-            "type" => "text",
+            "type" => $config['type'],
             "senderid" => $config['senderid'],
             "contacts" => $mobile,
-            "msg" => urlencode($text),
+            "msg" => $text,
         ];
 
         $requestUrl = $config['url'] . "/smsapi";


### PR DESCRIPTION
about type : 
if type not dynamic any bangla msg will be shown properly in user mobile , as it can be some time text and unicode 


msg : in previous version due to urlencode , its getting + added in every word middle of word "hello+how+are+you"  , so i remove urlencode